### PR TITLE
Changed children from string type to array type to silence yellowbox …

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ export default class TextMarquee extends PureComponent {
     marqueeOnMount:  PropTypes.bool,
     marqueeDelay:    PropTypes.number,
     useNativeDriver: PropTypes.bool,
-    children:        PropTypes.string,
+    children:        PropTypes.array,
     repeatSpacer:    PropTypes.number,
     easing:          PropTypes.func
   }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ export default class TextMarquee extends PureComponent {
     marqueeOnMount:  PropTypes.bool,
     marqueeDelay:    PropTypes.number,
     useNativeDriver: PropTypes.bool,
-    children:        PropTypes.array,
+    children:        PropTypes.oneOfType([
+                        PropTypes.string,
+                        PropTypes.array]),
     repeatSpacer:    PropTypes.number,
     easing:          PropTypes.func
   }


### PR DESCRIPTION
…warnings when using <Text> JSX inside <TextTicker>.  This lets us apply styling to substrings within the marquee.

<img width="187" alt="screen shot 2018-06-26 at 8 10 34 am" src="https://user-images.githubusercontent.com/39064173/41914376-81e86474-7918-11e8-92db-689c4c9c098b.png">
