### PR TITLE
Update styles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+    alignItems: 'center',
   },
 });
 


### PR DESCRIPTION
Example usage in readme was missing `alignItems: 'center'`, updated it to correct for that.