### PR TITLE
add optional onScrollStart prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const styles = StyleSheet.create({
 | marqueeOnMount  | boolean   | true     |  true    | Will start scroll as soon as component has mounted. Disable if using methods instead.
 | marqueeDelay    | number    | true     |  0       | Number of milliseconds to wait before starting marquee
 | onMarqueeComplete | function | true    |  -       | This function will run after the text has completely passed across the screen. Will run repeatedly if `loop` is enabled.
+| onScrollStart   | function  | true     |  -       | This function will run if the text is long enough to trigger the scroll.
 | isInteraction   | boolean   | true     | true     | Whether or not animations create an interaction handle on the `InteractionManager`. Disable if you are having issues with VirtualizedLists not rendering properly.
 | useNativeDriver | boolean   | true     | true     | Use native animation driver, should remain true for large majority of use-cases
 | repeatSpacer    | number    | true     | 50       | The space between the end of your text string ticker and the beginning of it starting again.

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export default class TextMarquee extends PureComponent {
     isInteraction:     PropTypes.bool,
     useNativeDriver:   PropTypes.bool,
     onMarqueeComplete: PropTypes.func,
+    onScrollStart:     PropTypes.func,
     children:          PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.array
@@ -157,6 +158,10 @@ export default class TextMarquee extends PureComponent {
     this.setTimeout(async () => {
       await this.calculateMetrics()
       if (!this.state.contentFits) {
+        const {onScrollStart} = this.props
+        if(onScrollStart && typeof onScrollStart === "function") {
+          onScrollStart()
+        }
         if (this.props.animationType === 'auto') {
           if (this.state.shouldBounce && this.props.bounce) {
             this.animateBounce()


### PR DESCRIPTION
`onScrollStart` will run once if the content doesn't fit and the scrolling will start.
I added this optional prop because I needed away to get feedback on when some dynamic text was long enough to trigger the scroll, so I could change some styling elsewhere.