### PR TITLE
Add check for valid animation values

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,23 +110,26 @@ export default class TextMarquee extends PureComponent {
       onMarqueeComplete
     } = this.props
     this.setTimeout(() => {
-      Animated.timing(this.animatedValue, {
-        toValue:         -this.textWidth - repeatSpacer,
-        duration:        duration || children.length * 150,
-        easing:          easing,
-        isInteraction:   isInteraction,
-        useNativeDriver: useNativeDriver
-      }).start(({ finished }) => {
-        if (finished) {
-          if (onMarqueeComplete) {
-            onMarqueeComplete()
+      if(!isNaN(-this.textWidth - repeatSpacer)) {
+        Animated.timing(this.animatedValue, {
+          toValue:         -this.textWidth - repeatSpacer,
+          duration:        duration || children.length * 150,
+          easing:          easing,
+          isInteraction:   isInteraction,
+          useNativeDriver: useNativeDriver
+        }).start(({ finished }) => {
+          if (finished) {
+            if (onMarqueeComplete) {
+              onMarqueeComplete()
+            }
+            if (loop) {
+              this.animatedValue.setValue(0)
+              this.animateScroll()
+            }
           }
-          if (loop) {
-            this.animatedValue.setValue(0)
-            this.animateScroll()
-          }
+        })} else {
+          this.start()
         }
-      })
     }, marqueeDelay)
   }
 

--- a/index.js
+++ b/index.js
@@ -110,9 +110,10 @@ export default class TextMarquee extends PureComponent {
       onMarqueeComplete
     } = this.props
     this.setTimeout(() => {
-      if(!isNaN(-this.textWidth - repeatSpacer)) {
+      const scrollToValue = -this.textWidth - repeatSpacer
+      if(!isNaN(scrollToValue)) {
         Animated.timing(this.animatedValue, {
-          toValue:         -this.textWidth - repeatSpacer,
+          toValue:         scrollToValue,
           duration:        duration || children.length * 150,
           easing:          easing,
           isInteraction:   isInteraction,


### PR DESCRIPTION
I have `FlatList` list items with `TextTicker` in the components. When I have several items loaded and scroll quickly, I was getting these crashes consistently on Android (iOS was fine).

The issue seems to come from within the `calculateMetrics` method. Sometimes one or both of `containerWidth` and `textWidth` would be `undefined`. This might have to do with components not loading in time in a list. 

This would lead to the Animated.timing `toValue` in `animatedScroll` being `NaN`. 
I wrapped that in an if/else. If it doesn't have valid values to pass to `Animated`, then it will run the `start` method again. This prevents the error and eventually triggers text scrolling once valid values are returned. 

I haven't run into any infinite loops, but I can also try to add a retry counter if you'd like.  

![1](https://user-images.githubusercontent.com/30599893/60699045-1d929080-9f2d-11e9-8f1a-7aa184e14d1a.png)
![2](https://user-images.githubusercontent.com/30599893/60699046-1ec3bd80-9f2d-11e9-88df-7326691ce684.png)

