### PR TITLE
Add scrolling speed and rename to bounceSpeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
 | style           | StyleObj  | true     | -        | Text Style
 | duration        | number    | true     | `150ms` * length of string | Number of milliseconds until animation finishes
 | bounceSpeed     | number    | true     |  50      | Describes how fast the bounce animation moves. Effective when duration is not set.  When effective, the duration will depends on the width of text and screen width
-| scrollingSpeed  | number    | true     |  150     | Describes how fast the scrolling animation moves. Effective when duration is not set.  When effective, the duration will depends on the width of text and screen width
+| scrollSpeed     | number    | true     |  150     | Describes how fast the scroll animation moves. Effective when duration is not set.  When effective, the duration will depends on the width of text and screen width
 | animationType   | string    | true     | 'auto'   | one of the values from 'auto', 'scroll', 'bounce'
 | loop            | boolean   | true     |  true    | Infinitely scroll the text, effective when animationType is 'auto'
 | bounce          | boolean   | true     |  true    | If text is only slightly longer than its container then bounce back/forwards instead of full scroll, effective when animationType is 'auto'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ const styles = StyleSheet.create({
 |-----------------|-----------|----------|----------|-------------
 | style           | StyleObj  | true     | -        | Text Style
 | duration        | number    | true     | `150ms` * length of string | Number of milliseconds until animation finishes
-| scrollingSpeed  | number    | true     |  50      | Describes how fast the bounce animation moves. Effective when duration is not set.  When effective, the duration will depends on the width of text and screen width
+| bounceSpeed  | number    | true     |  50      | Describes how fast the bounce animation moves. Effective when duration is not set.  When effective, the duration will depends on the width of text and screen width
+| scrollingSpeed  | number    | true     |  150     | Describes how fast the scrolling animation moves. Effective when duration is not set.  When effective, the duration will depends on the width of text and screen width
 | animationType   | string    | true     | 'auto'   | one of the values from 'auto', 'scroll', 'bounce'
 | loop            | boolean   | true     |  true    | Infinitely scroll the text, effective when animationType is 'auto'
 | bounce          | boolean   | true     |  true    | If text is only slightly longer than its container then bounce back/forwards instead of full scroll, effective when animationType is 'auto'

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ export default class TextMarquee extends PureComponent {
     easing:            PropTypes.func,
     animationType:     PropTypes.string, // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
     bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
-    scrollingSpeed:    PropTypes.number, // Will be ignored if you set duration directly.
+    scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
     shouldAnimateTreshold: PropTypes.number
   }
 
@@ -58,7 +58,7 @@ export default class TextMarquee extends PureComponent {
     easing:            Easing.ease,
     animationType:     'auto',
     bounceSpeed:       50,
-    scrollingSpeed:    150,
+    scrollSpeed:       150,
     shouldAnimateTreshold: 0
   }
 
@@ -111,7 +111,7 @@ export default class TextMarquee extends PureComponent {
       repeatSpacer,
       easing,
       children,
-      scrollingSpeed,
+      scrollSpeed,
       onMarqueeComplete
     } = this.props
     this.setTimeout(() => {
@@ -119,7 +119,7 @@ export default class TextMarquee extends PureComponent {
       if(!isNaN(scrollToValue)) {
         Animated.timing(this.animatedValue, {
           toValue:         scrollToValue,
-          duration:        duration || children.length * scrollingSpeed,
+          duration:        duration || children.length * scrollSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
           useNativeDriver: useNativeDriver

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ export default class TextMarquee extends PureComponent {
     ]),
     repeatSpacer:      PropTypes.number,
     easing:            PropTypes.func,
-    animationType:     PropTypes.string, //(values should be from AnimationType, 'auto', 'scroll', 'bounce')
-    scrollingSpeed:    PropTypes.number, //Will be ignored if you set duration directly.
+    animationType:     PropTypes.string, // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
+    bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
+    scrollingSpeed:    PropTypes.number, // Will be ignored if you set duration directly.
     shouldAnimateTreshold: PropTypes.number
   }
 
@@ -56,7 +57,8 @@ export default class TextMarquee extends PureComponent {
     repeatSpacer:      50,
     easing:            Easing.ease,
     animationType:     'auto',
-    scrollingSpeed:    50,
+    bounceSpeed:       50,
+    scrollingSpeed:    150,
     shouldAnimateTreshold: 0
   }
 
@@ -109,6 +111,7 @@ export default class TextMarquee extends PureComponent {
       repeatSpacer,
       easing,
       children,
+      scrollingSpeed,
       onMarqueeComplete
     } = this.props
     this.setTimeout(() => {
@@ -116,7 +119,7 @@ export default class TextMarquee extends PureComponent {
       if(!isNaN(scrollToValue)) {
         Animated.timing(this.animatedValue, {
           toValue:         scrollToValue,
-          duration:        duration || children.length * 150,
+          duration:        duration || children.length * scrollingSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
           useNativeDriver: useNativeDriver
@@ -137,19 +140,19 @@ export default class TextMarquee extends PureComponent {
   }
 
   animateBounce = () => {
-    const {duration, marqueeDelay, loop, isInteraction, useNativeDriver, easing, children, scrollingSpeed} = this.props
+    const {duration, marqueeDelay, loop, isInteraction, useNativeDriver, easing, children, bounceSpeed} = this.props
     this.setTimeout(() => {
       Animated.sequence([
         Animated.timing(this.animatedValue, {
           toValue:         -this.distance - 10,
-          duration:        duration || (this.distance) * scrollingSpeed,
+          duration:        duration || (this.distance) * bounceSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
           useNativeDriver: useNativeDriver
         }),
         Animated.timing(this.animatedValue, {
           toValue:         10,
-          duration:        duration || (this.distance) * scrollingSpeed,
+          duration:        duration || (this.distance) * bounceSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
           useNativeDriver: useNativeDriver

--- a/react-native-text-ticker.d.ts
+++ b/react-native-text-ticker.d.ts
@@ -17,7 +17,8 @@ declare module 'react-native-text-ticker' {
     repeatSpacer?: number;
     easing?: (value: number) => number;
     animationType?: string;
-    scrollingSpeed?: number;
+    scrollSpeed?: number;
+    bounceSpeed?: number;
     shouldAnimateTreshold?: number;
   }
 


### PR DESCRIPTION
The current scrollingSpeed is confusingly the bounce speed. And the actual scrolling speed is a fixed value of 150.

I renamed the scrollingSpeed to bounceSpeed, and moved the fixed 150 value to a new prop called scrollingSpeed.

I do realise that this is a BC break, but I think it's for the better. If both my PRs end up getting merged I'll update the types of the other PR to include the new prop in this PR as well.