### PR TITLE
FlatList Compatibility + fix for setState on unmount issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ react-native-text-ticker supports a single child text string, any other use may 
 | repeatSpacer    | number    | true     | 50       | The space between the end of your text string ticker and the beginning of it starting again.
 | easing          | function  | true     | Easing.ease | How the text scrolling animates. Additional options available from the [Easing module](https://facebook.github.io/react-native/docs/easing.html)
 | shouldAnimateTreshold | number | true  | 0        | If you have a view drawn over the text at the right (a fade-out gradient for instance) this should be set to the width of the overlaying view: ![examples](./example/media/example2.gif)
-
+| disabled        | boolean   | true     | false    | Disables text animation
 
 ## Methods
 These methods are optional and can be accessed by accessing the ref:

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ export default class TextMarquee extends PureComponent {
     animationType:     PropTypes.string, // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
     bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
     scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
-    shouldAnimateTreshold: PropTypes.number
+    shouldAnimateTreshold: PropTypes.number,
+    disabled:          PropTypes.bool
   }
 
   static defaultProps = {
@@ -60,7 +61,8 @@ export default class TextMarquee extends PureComponent {
     animationType:     'auto',
     bounceSpeed:       50,
     scrollSpeed:       150,
-    shouldAnimateTreshold: 0
+    shouldAnimateTreshold: 0,
+    disabled:          false
   }
 
   animatedValue = new Animated.Value(0)
@@ -77,8 +79,8 @@ export default class TextMarquee extends PureComponent {
 
   componentDidMount() {
     this.invalidateMetrics()
-    const { marqueeDelay, marqueeOnMount } = this.props
-    if (marqueeOnMount) {
+    const { disabled, marqueeDelay, marqueeOnMount } = this.props
+    if (!disabled && marqueeOnMount) {
       this.startAnimation(marqueeDelay)
     }
   }
@@ -86,6 +88,10 @@ export default class TextMarquee extends PureComponent {
   componentDidUpdate(prevProps) {
     if (this.props.children !== prevProps.children) {
       this.resetScroll()
+    } else if (this.props.disabled !== prevProps.disabled) {
+      if (!this.props.disabled && this.props.marqueeOnMount) {
+        this.startAnimation(this.props.marqueeDelay)
+      }
     }
   }
 
@@ -274,7 +280,7 @@ export default class TextMarquee extends PureComponent {
   }
 
   render() {
-    const { style, children, repeatSpacer, scroll, shouldAnimateTreshold, ... props } = this.props
+    const { style, children, repeatSpacer, scroll, shouldAnimateTreshold, disabled, ... props } = this.props
     const { animating, contentFits, isScrolling } = this.state
     const additionalContainerStyle = {
       // This is useful for shouldAnimateTreshold only:
@@ -284,6 +290,19 @@ export default class TextMarquee extends PureComponent {
       // In this case, it would be impossible to determine if animating is necessary based on the width of the container
       // (contentFits in calculateMetrics() would always be true)
       flex: shouldAnimateTreshold ? 1 : undefined
+    }
+    if (disabled) {
+      return (
+        <View style={[styles.container, additionalContainerStyle]}>
+          <Text
+            {...props}
+            numberOfLines={1}
+            style={[style, { opacity: animating ? 0 : 1 }]}
+          >
+            {this.props.children}
+          </Text>
+        </View>
+      )
     }
     return (
       <View style={[styles.container, additionalContainerStyle]}>

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ export default class TextMarquee extends PureComponent {
   }
 
   componentWillMount() {
-    this.calculateMetricsPromise = null;
+    this.calculateMetricsPromise = null
   }
 
   componentDidMount() {
@@ -96,44 +96,45 @@ export default class TextMarquee extends PureComponent {
       if (!this.props.disabled && this.props.marqueeOnMount) {
         this.startAnimation(this.props.marqueeDelay)
       } else if (this.props.disabled) {
-        this.stopAnimation();
-        this.clearTimeout();
+        this.stopAnimation()
+        this.clearTimeout()
       }
     }
   }
 
   componentWillUnmount() {
+    // Cancel promise to stop setState after unmount
     if (this.calculateMetricsPromise !== null) {
-      this.calculateMetricsPromise.cancel();
-      this.calculateMetricsPromise = null;
+      this.calculateMetricsPromise.cancel()
+      this.calculateMetricsPromise = null
     }
-    this.stopAnimation();
+    this.stopAnimation()
     // always stop timers when unmounting, common source of crash
-    this.clearTimeout();
+    this.clearTimeout()
   }
 
   makeCancelable = (promise) => {
-    let cancel = () => {};
+    let cancel = () => {}
     const wrappedPromise = new Promise((resolve, reject) => {
       cancel = () => {
         resolve = null
         reject = null
       };
       promise.then(
-        val => {
+        value => {
           if (resolve) {
-            resolve(val);
+            resolve(value)
           }
         }, 
         error => {
           if (reject) {
-            reject(error);
+            reject(error)
           }
         }
       );
     });
-    wrappedPromise.cancel = cancel;
-    return wrappedPromise;
+    wrappedPromise.cancel = cancel
+    return wrappedPromise
   };
 
   startAnimation = (timeDelay) => {
@@ -256,7 +257,6 @@ export default class TextMarquee extends PureComponent {
               return reject('nodehandle_not_found');
             }
           });
-          
         const [containerWidth, textWidth] = await Promise.all([
           measureWidth(this.containerRef),
           measureWidth(this.textRef)
@@ -273,18 +273,17 @@ export default class TextMarquee extends PureComponent {
           contentFits:  this.distance <= 1,
           shouldBounce: this.distance < this.containerWidth / 8
         })
-        
       } catch (error) {
         console.warn('react-native-text-ticker: could not calculate metrics', error);
       }
-    }));
+    }))
     await this.calculateMetricsPromise.then((result) => {
       this.setState({
         contentFits: result.contentFits,
         shouldBounce: result.shouldBounce,
-      });
-      return [];
-    });
+      })
+      return []
+    })
   }
 
   invalidateMetrics = () => {

--- a/index.js
+++ b/index.js
@@ -337,19 +337,6 @@ export default class TextMarquee extends PureComponent {
       // (contentFits in calculateMetrics() would always be true)
       flex: shouldAnimateTreshold ? 1 : undefined
     }
-    if (disabled) {
-      return (
-        <View style={[styles.container, additionalContainerStyle]}>
-          <Text
-            {...props}
-            numberOfLines={1}
-            style={[style, { opacity: animating ? 0 : 1 }]}
-          >
-            {this.props.children}
-          </Text>
-        </View>
-      )
-    }
     const animatedText = disabled ? null : (
       <ScrollView
         ref={c => (this.containerRef = c)}

--- a/index.js
+++ b/index.js
@@ -91,6 +91,9 @@ export default class TextMarquee extends PureComponent {
     } else if (this.props.disabled !== prevProps.disabled) {
       if (!this.props.disabled && this.props.marqueeOnMount) {
         this.startAnimation(this.props.marqueeDelay)
+      } else if (this.props.disabled) {
+        this.stopAnimation();
+        this.clearTimeout();
       }
     }
   }


### PR DESCRIPTION
## Context
- I was looking to use this lib within a component being rendered as a FlatList item. When using a large list I started to see lots of `'react-native-text-ticker: could not calculate metrics', 'nodehandle_not_found'` errors and the text-ticker was displaying weird behavior with text animations (The smallest list I seen this occur was ~30 items).

## Change Description 
- Added `disabled` field so that the animation can be stopped. I have used this with the FlatList's `onViewableItemsChanged` callback so that any item which is not currently on screen will not animate.
- Added `makeCancellable()` to allow promises to be cancelled in `componentWillUnmount()`. This will cleanup any unresolved promises to resolve the unmounted setState warning. `resolve` and `reject` have been nulled to help with GC. 
NOTE: This is not a perfect fix, but I believe that it is the best approach for now. More Details:
https://github.com/reactjs/reactjs.org/pull/2562