### PR TITLE
Fix for unsafe `componentWillMount` warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,10 +77,11 @@ export default class TextMarquee extends PureComponent {
     isScrolling:  false
   }
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     this.calculateMetricsPromise = null
   }
-
+  
   componentDidMount() {
     this.invalidateMetrics()
     const { disabled, marqueeDelay, marqueeOnMount } = this.props


### PR DESCRIPTION
## Description
- Fixed unsafe `componentWillMount` warning by moving initialization to constructor.