### PR TITLE
Improve RTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ react-native-text-ticker supports a single child text string, any other use may 
 | easing          | function  | true     | Easing.ease | How the text scrolling animates. Additional options available from the [Easing module](https://facebook.github.io/react-native/docs/easing.html)
 | shouldAnimateTreshold | number | true  | 0        | If you have a view drawn over the text at the right (a fade-out gradient for instance) this should be set to the width of the overlaying view: ![examples](./example/media/example2.gif)
 | disabled        | boolean   | true     | false    | Disables text animation
+| isRTL        | boolean   | true     | false    | If text is right to left (By default, it uses `I18nManager.isRTL` to check)
 
 ## Methods
 These methods are optional and can be accessed by accessing the ref:

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ export default class TextMarquee extends PureComponent {
     bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
     scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
     shouldAnimateTreshold: PropTypes.number,
-    disabled:          PropTypes.bool
+    disabled:          PropTypes.bool,
+    isRTL:             PropTypes.bool
   }
 
   static defaultProps = {
@@ -62,7 +63,8 @@ export default class TextMarquee extends PureComponent {
     bounceSpeed:       50,
     scrollSpeed:       150,
     shouldAnimateTreshold: 0,
-    disabled:          false
+    disabled:          false,
+    isRTL:             undefined
   }
 
   animatedValue = new Animated.Value(0)
@@ -161,10 +163,11 @@ export default class TextMarquee extends PureComponent {
       easing,
       children,
       scrollSpeed,
-      onMarqueeComplete
+      onMarqueeComplete,
+      isRTL
     } = this.props
     this.setTimeout(() => {
-      const scrollToValue = I18nManager.isRTL ? this.textWidth + repeatSpacer : -this.textWidth - repeatSpacer
+      const scrollToValue = isRTL ?? I18nManager.isRTL ? this.textWidth + repeatSpacer : -this.textWidth - repeatSpacer
       if(!isNaN(scrollToValue)) {
         Animated.timing(this.animatedValue, {
           toValue:         scrollToValue,
@@ -189,18 +192,18 @@ export default class TextMarquee extends PureComponent {
   }
 
   animateBounce = () => {
-    const {duration, marqueeDelay, loop, isInteraction, useNativeDriver, easing, children, bounceSpeed} = this.props
+    const {duration, marqueeDelay, loop, isInteraction, useNativeDriver, easing, bounceSpeed, isRTL} = this.props
     this.setTimeout(() => {
       Animated.sequence([
         Animated.timing(this.animatedValue, {
-          toValue:         I18nManager.isRTL ? this.distance + 10 : -this.distance - 10,
+          toValue:         isRTL ?? I18nManager.isRTL ? this.distance + 10 : -this.distance - 10,
           duration:        duration || (this.distance) * bounceSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
           useNativeDriver: useNativeDriver
         }),
         Animated.timing(this.animatedValue, {
-          toValue:         I18nManager.isRTL ? -10 : 10,
+          toValue:         isRTL ?? I18nManager.isRTL ? -10 : 10,
           duration:        duration || (this.distance) * bounceSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
@@ -327,7 +330,7 @@ export default class TextMarquee extends PureComponent {
   }
 
   render() {
-    const { style, children, repeatSpacer, scroll, shouldAnimateTreshold, disabled, ... props } = this.props
+    const { style, children, repeatSpacer, scroll, shouldAnimateTreshold, disabled, isRTL, ... props } = this.props
     const { animating, contentFits, isScrolling } = this.state
     const additionalContainerStyle = {
       // This is useful for shouldAnimateTreshold only:
@@ -347,7 +350,7 @@ export default class TextMarquee extends PureComponent {
         onScrollBeginDrag={this.scrollBegin}
         onScrollEndDrag={this.scrollEnd}
         showsHorizontalScrollIndicator={false}
-        style={[StyleSheet.absoluteFillObject, I18nManager.isRTL ? { flexDirection: 'row-reverse' } : null ]}
+        style={[StyleSheet.absoluteFillObject, (isRTL ?? I18nManager.isRTL) && { flexDirection: 'row-reverse' } ]}
         display={animating ? 'flex' : 'none'}
         onContentSizeChange={() => this.calculateMetrics()}
       >

--- a/react-native-text-ticker.d.ts
+++ b/react-native-text-ticker.d.ts
@@ -20,6 +20,7 @@ declare module 'react-native-text-ticker' {
     scrollSpeed?: number;
     bounceSpeed?: number;
     shouldAnimateTreshold?: number;
+    isRTL: boolean;
   }
 
   export default class TextTicker<T> extends React.Component<TextTickerProps> { }


### PR DESCRIPTION
Hey

There was a great effort in https://github.com/deanhet/react-native-text-ticker/pull/64 which adds RTL support but I guess there is a problem! Sometimes developer locks the app to LTR and handle the directions manually.

I think it's better to have it as a prop.