### PR TITLE
Fix truthiness check of marqueeDelay

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,10 +326,12 @@ export default class TextMarquee extends PureComponent {
   }
 
   scrollEnd = () => {
+    const { marqueeDelay } = this.props
+    
     this.setTimeout(() => {
       this.setState({ isScrolling: false })
       this.start()
-    }, this.props.marqueeDelay || 3000)
+    }, marqueeDelay >= 0 ? marqueeDelay : 3000)
   }
 
   resetScroll = () => {


### PR DESCRIPTION
- Previously, `marqueeDelay` set to `0` (it is also defaulted to be set to `0`) was being overwritten by the default scroll delay of `3000` because `0` is falsey
- This checks `marqueeDelay >= 0`

Notes: Because `marqueeDelay` is defaulted to set to `0`, `marqueeDelay` would have to be set to a null value for `3000ms` to be reached