### PR TITLE
Fix "Invalid prop `children`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ export default class TextMarquee extends PureComponent {
     onScrollStart:     PropTypes.func,
     children:          PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.array
+      PropTypes.array,
+      PropTypes.node,
     ]),
     repeatSpacer:      PropTypes.number,
     easing:            PropTypes.func,


### PR DESCRIPTION
When using third-party components for text (for example, title from react-native-paper), there was a warning: Invalid prop `children` supplied to `TextMarquee`.  But at the same time everything worked and the scroll was executed as it should. Now the warning is not displayed.