### PR TITLE
Fix: Prop types

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ export default class TextMarquee extends PureComponent {
     ]),
     repeatSpacer:      PropTypes.number,
     easing:            PropTypes.func,
-    animationType:     PropTypes.string, // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
+    animationType:     PropTypes.oneOf('auto', 'scroll', 'bounce'), // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
     bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
     scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
     bouncePadding:     PropTypes.shape({

--- a/react-native-text-ticker.d.ts
+++ b/react-native-text-ticker.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-native-text-ticker' {
   import React from 'react';
-  import { StyleProp, TextProps, TextStyle } from 'react-native';
+  import { StyleProp, TextProps, TextStyle, EasingFunction } from 'react-native';
 
   export interface TextTickerProps extends TextProps {
     duration?: number;
@@ -12,15 +12,21 @@ declare module 'react-native-text-ticker' {
     scroll?: boolean;
     marqueeOnMount?: boolean;
     marqueeDelay?: number;
+    bounceDelay?: number;
     isInteraction?: boolean;
     useNativeDriver?: boolean;
     repeatSpacer?: number;
-    easing?: (value: number) => number;
-    animationType?: string;
+    easing?: EasingFunction;
+    animationType?: 'auto' | 'scroll' | 'bounce';
     scrollSpeed?: number;
     bounceSpeed?: number;
     shouldAnimateTreshold?: number;
-    isRTL: boolean;
+    isRTL?: boolean;
+    bouncePadding?: {
+      left?: number;
+      right?: number;
+    }
+    disabled?: boolean;
   }
 
   export default class TextTicker<T> extends React.Component<TextTickerProps> { }


### PR DESCRIPTION
While using the component with TypeScript, encountered some prop erros (like `Property 'bounceDelay' does not exist` or `Property 'isRTL' is missing`). Just fixing this to prevent some unnecessary errors popping up.