### PR TITLE
Show text when animation is disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -393,7 +393,7 @@ export default class TextMarquee extends PureComponent {
         <Text
           {...props}
           numberOfLines={1}
-          style={[style, { opacity: animating ? 0 : 1 }]}
+          style={[style, { opacity: !disabled && animating ? 0 : 1 }]}
         >
           {this.props.children}
         </Text>


### PR DESCRIPTION
Encountered bug where disabling animation hide text & leave a blank space
This change will ensure that static text will always show when animation is disabled