### PR TITLE
Remove unused variable (timeDelay)

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,11 +153,11 @@ export default class TextMarquee extends PureComponent {
     return wrappedPromise
   };
 
-  startAnimation = (timeDelay) => {
+  startAnimation = () => {
     if (this.state.animating) {
       return
     }
-    this.start(timeDelay)
+    this.start()
   }
 
   animateScroll = () => {
@@ -232,7 +232,7 @@ export default class TextMarquee extends PureComponent {
     }, this.hasFinishedFirstLoop ? bounceDelay > 0 ? bounceDelay : 0 : marqueeDelay)
   }
 
-  start = async (timeDelay) => {
+  start = async () => {
     this.setState({ animating: true })
     this.setTimeout(async () => {
       await this.calculateMetrics()


### PR DESCRIPTION
Seems like the project moved to not using timeDelay supplied in `startAnimation`. This just cleans it up a bit so that unused variable isn't lingering.