### PR TITLE
Add types for ref

### DIFF
--- a/react-native-text-ticker.d.ts
+++ b/react-native-text-ticker.d.ts
@@ -29,5 +29,10 @@ declare module 'react-native-text-ticker' {
     disabled?: boolean;
   }
 
-  export default class TextTicker<T> extends React.Component<TextTickerProps> { }
+  export interface TextTickerRef {
+    startAnimation(): void;
+    stopAnimation(): void;
+  }
+
+  export default class TextTicker extends React.Component<TextTickerProps> { }
 }


### PR DESCRIPTION
Adding some types for `TextTickerRef` for more added typesafety :).

Also minor change was to remove generic variable T, as it wasn't being used.