### PR TITLE
fix: Use textWidth instead of length

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ export default class TextMarquee extends PureComponent {
       if(!isNaN(scrollToValue)) {
         Animated.timing(this.animatedValue, {
           toValue:         scrollToValue,
-          duration:        duration || children.length * scrollSpeed,
+          duration:        duration || this.textWidth * scrollSpeed,
           easing:          easing,
           isInteraction:   isInteraction,
           useNativeDriver: useNativeDriver


### PR DESCRIPTION
Variable-width fonts will scroll much faster for longer text