### PR TITLE
Make library compatible with Expo Web

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ import {
   NativeModules,
   findNodeHandle,
   I18nManager,
-  TextStyle,
 } from 'react-native'
 import PropTypes from 'prop-types'
 
@@ -24,7 +23,7 @@ export const TextTickAnimationType = Object.freeze({
 export default class TextMarquee extends PureComponent {
 
   static propTypes = {
-    style:             TextStyle,
+    style:             PropTypes.any,
     duration:          PropTypes.number,
     loop:              PropTypes.bool,
     bounce:            PropTypes.bool,

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import {
   ScrollView,
   NativeModules,
   findNodeHandle,
-  I18nManager,
+  I18nManager
 } from 'react-native'
 import PropTypes from 'prop-types'
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import {
   NativeModules,
   findNodeHandle,
   I18nManager,
-  TextPropTypes,
+  TextStyle,
 } from 'react-native'
 import PropTypes from 'prop-types'
 
@@ -24,7 +24,7 @@ export const TextTickAnimationType = Object.freeze({
 export default class TextMarquee extends PureComponent {
 
   static propTypes = {
-    style:             TextPropTypes.style,
+    style:             TextStyle,
     duration:          PropTypes.number,
     loop:              PropTypes.bool,
     bounce:            PropTypes.bool,

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ import {
   findNodeHandle,
   I18nManager
 } from 'react-native'
-import PropTypes from 'prop-types'
 
 const { UIManager } = NativeModules
 
@@ -21,39 +20,6 @@ export const TextTickAnimationType = Object.freeze({
 })
 
 export default class TextMarquee extends PureComponent {
-
-  static propTypes = {
-    style:             PropTypes.any,
-    duration:          PropTypes.number,
-    loop:              PropTypes.bool,
-    bounce:            PropTypes.bool,
-    scroll:            PropTypes.bool,
-    marqueeOnMount:    PropTypes.bool,
-    marqueeDelay:      PropTypes.number,
-    isInteraction:     PropTypes.bool,
-    useNativeDriver:   PropTypes.bool,
-    onMarqueeComplete: PropTypes.func,
-    onScrollStart:     PropTypes.func,
-    children:          PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.array,
-      PropTypes.node,
-    ]),
-    repeatSpacer:      PropTypes.number,
-    easing:            PropTypes.func,
-    animationType:     PropTypes.oneOf(['auto', 'scroll', 'bounce']), // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
-    bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
-    scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
-    bouncePadding:     PropTypes.shape({
-      left: PropTypes.number,
-      right: PropTypes.number
-    }),
-    bounceDelay: PropTypes.number,
-    shouldAnimateTreshold: PropTypes.number,
-    disabled:          PropTypes.bool,
-    isRTL:             PropTypes.bool
-  }
-
   static defaultProps = {
     style:             {},
     loop:              true,

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ import {
   findNodeHandle,
   I18nManager
 } from 'react-native'
-import PropTypes from 'prop-types'
 
 const { UIManager } = NativeModules
 
@@ -21,60 +20,6 @@ export const TextTickAnimationType = Object.freeze({
 })
 
 export default class TextMarquee extends PureComponent {
-
-  static propTypes = {
-    style:             PropTypes.any,
-    duration:          PropTypes.number,
-    loop:              PropTypes.bool,
-    bounce:            PropTypes.bool,
-    scroll:            PropTypes.bool,
-    marqueeOnMount:    PropTypes.bool,
-    marqueeDelay:      PropTypes.number,
-    isInteraction:     PropTypes.bool,
-    useNativeDriver:   PropTypes.bool,
-    onMarqueeComplete: PropTypes.func,
-    onScrollStart:     PropTypes.func,
-    children:          PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.array,
-      PropTypes.node,
-    ]),
-    repeatSpacer:      PropTypes.number,
-    easing:            PropTypes.func,
-    animationType:     PropTypes.oneOf(['auto', 'scroll', 'bounce']), // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
-    bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
-    scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
-    bouncePadding:     PropTypes.shape({
-      left: PropTypes.number,
-      right: PropTypes.number
-    }),
-    bounceDelay: PropTypes.number,
-    shouldAnimateTreshold: PropTypes.number,
-    disabled:          PropTypes.bool,
-    isRTL:             PropTypes.bool
-  }
-
-  static defaultProps = {
-    style:             {},
-    loop:              true,
-    bounce:            true,
-    scroll:            true,
-    marqueeOnMount:    true,
-    marqueeDelay:      0,
-    isInteraction:     true,
-    useNativeDriver:   true,
-    repeatSpacer:      50,
-    easing:            Easing.ease,
-    animationType:     'auto',
-    bounceSpeed:       50,
-    scrollSpeed:       150,
-    bouncePadding:     undefined,
-    bounceDelay: 0,
-    shouldAnimateTreshold: 0,
-    disabled:          false,
-    isRTL:             undefined
-  }
-
   animatedValue = new Animated.Value(0)
   distance = null
   textRef = null

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import {
   findNodeHandle,
   I18nManager
 } from 'react-native'
+import PropTypes from 'prop-types'
 
 const { UIManager } = NativeModules
 
@@ -20,6 +21,60 @@ export const TextTickAnimationType = Object.freeze({
 })
 
 export default class TextMarquee extends PureComponent {
+
+  static propTypes = {
+    style:             PropTypes.any,
+    duration:          PropTypes.number,
+    loop:              PropTypes.bool,
+    bounce:            PropTypes.bool,
+    scroll:            PropTypes.bool,
+    marqueeOnMount:    PropTypes.bool,
+    marqueeDelay:      PropTypes.number,
+    isInteraction:     PropTypes.bool,
+    useNativeDriver:   PropTypes.bool,
+    onMarqueeComplete: PropTypes.func,
+    onScrollStart:     PropTypes.func,
+    children:          PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.array,
+      PropTypes.node,
+    ]),
+    repeatSpacer:      PropTypes.number,
+    easing:            PropTypes.func,
+    animationType:     PropTypes.oneOf(['auto', 'scroll', 'bounce']), // (values should be from AnimationType, 'auto', 'scroll', 'bounce')
+    bounceSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
+    scrollSpeed:       PropTypes.number, // Will be ignored if you set duration directly.
+    bouncePadding:     PropTypes.shape({
+      left: PropTypes.number,
+      right: PropTypes.number
+    }),
+    bounceDelay: PropTypes.number,
+    shouldAnimateTreshold: PropTypes.number,
+    disabled:          PropTypes.bool,
+    isRTL:             PropTypes.bool
+  }
+
+  static defaultProps = {
+    style:             {},
+    loop:              true,
+    bounce:            true,
+    scroll:            true,
+    marqueeOnMount:    true,
+    marqueeDelay:      0,
+    isInteraction:     true,
+    useNativeDriver:   true,
+    repeatSpacer:      50,
+    easing:            Easing.ease,
+    animationType:     'auto',
+    bounceSpeed:       50,
+    scrollSpeed:       150,
+    bouncePadding:     undefined,
+    bounceDelay: 0,
+    shouldAnimateTreshold: 0,
+    disabled:          false,
+    isRTL:             undefined
+  }
+
   animatedValue = new Animated.Value(0)
   distance = null
   textRef = null

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ import {
   ScrollView,
   NativeModules,
   findNodeHandle,
-  I18nManager
+  I18nManager,
+  TextPropTypes,
 } from 'react-native'
 import PropTypes from 'prop-types'
 
@@ -23,7 +24,7 @@ export const TextTickAnimationType = Object.freeze({
 export default class TextMarquee extends PureComponent {
 
   static propTypes = {
-    style:             Text.propTypes.style,
+    style:             TextPropTypes.style,
     duration:          PropTypes.number,
     loop:              PropTypes.bool,
     bounce:            PropTypes.bool,


### PR DESCRIPTION
Related to #81, when trying to use this library with Expo, an error is thrown when importing. The library chokes on `Text.propTypes.style`. Admittedly I am not sure how to properly import PropTypes from React Native, as it seems that they have been deprecated, but regardless there is no reason I can think of as to why this library should not be considered compatible with Expo when an app is being previewed in web-mode.