### PR TITLE
import ScrollView from gesture-handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,12 @@ import {
   StyleSheet,
   Text,
   View,
-  ScrollView,
   NativeModules,
   findNodeHandle,
   I18nManager
 } from 'react-native'
+
+import { ScrollView } from 'react-native-gesture-handler';
 
 const { UIManager } = NativeModules
 


### PR DESCRIPTION
IMPORTANT!!! import ScrollView from **_react-native-gesture-handler_** instead just react-native. this mode allows the user - even if the TextTicker is already inside a ScrollView (horizontal) - to grab the text and drag (with the 'scroll' property active). Without the gesture-handler, this is not possible, the drag does not work (only scroll the FATHER ScrollView, the son doesn't scroll). 
Video showing the problem and after fixed:
https://www.youtube.com/watch?v=Ev1_tT98kDI&ab_channel=ManoeldeOliveiraPradoNeto
Project as an example in the following repository: 
https://github.com/ManoelPradoMark22/ignite_reactNative_gofinances_project2
My commit when I add the react-native-text-ticker lib:
https://github.com/ManoelPradoMark22/ignite_reactNative_gofinances_project2/commit/0f629037a04547345e2125f0b66491c655199f60