### PR TITLE
Fix text stuck in animation state

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,6 +263,11 @@ export default class TextMarquee extends PureComponent {
       }
     }))
     await this.calculateMetricsPromise.then((result) => {
+      if (result.contentFits) {
+        // Reset animatedValue to 0 if content fits;
+        // this avoids content get stuck in animation
+        this.animatedValue.setValue(0);
+      }
       this.setState({
         contentFits: result.contentFits,
         shouldBounce: result.shouldBounce,


### PR DESCRIPTION
For Android I found in 1.14.0, as well as for new 1.14.1, that the Text can be stuck in a in-animation state/position when it updated from a longer text that required animating to a shorter one that does not.

This Fix ensures that the `animatedValue` is set to zero if the content fits.


RN: 0.80.2 (also saw this on 0.79.x and possibly on 0.76.x, not sure anymore, did to much upgrading the past weeks...)