### PR TITLE
Migrate absoluteFillObject to absoluteFill

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ export default class TextMarquee extends PureComponent {
         onScrollBeginDrag={this.scrollBegin}
         onScrollEndDrag={this.scrollEnd}
         showsHorizontalScrollIndicator={false}
-        style={[StyleSheet.absoluteFillObject, (isRTL ?? I18nManager.isRTL) && { flexDirection: 'row-reverse' } ]}
+        style={[StyleSheet.absoluteFill, (isRTL ?? I18nManager.isRTL) && { flexDirection: 'row-reverse' } ]}
         display={animating ? 'flex' : 'none'}
         onContentSizeChange={() => this.calculateMetrics()}
       >


### PR DESCRIPTION
`StyleSheet.absoluteFillObject` was removed in RN 0.85 so I've updated here as per the instructions in the [RN blog post](https://reactnative.dev/blog/2026/04/07/react-native-0.85#stylesheetabsolutefillobject-removed).